### PR TITLE
chore: update dependencies to 'community-edition'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,13 +19,13 @@ clap-num = "1.0.2"
 halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2023_02_02" }
 
 # Axiom's helper API with basic functions 
-halo2-base = { git = "https://github.com/axiom-crypto/halo2-lib", branch = "axiom-dev-0406" }
+halo2-base = { git = "https://github.com/axiom-crypto/halo2-lib", branch = "community-edition" }
 # Axiom poseidon chip (adapted from Scroll)
-poseidon = { git = "https://github.com/axiom-crypto/halo2-lib", branch = "axiom-dev-0406" }
+poseidon = { git = "https://github.com/axiom-crypto/halo2-lib", branch = "community-edition" }
 # Axiom Evm wrapper 
-axiom-eth = { git = "https://github.com/axiom-crypto/axiom-eth.git", branch = "axiom-dev-0406", default-features = false, features = ["halo2-axiom", "aggregation", "evm", "clap"] }
-snark-verifier-sdk = { git = "https://github.com/axiom-crypto/snark-verifier.git", branch = "axiom-dev-0406", default-features = false, features = ["loader_halo2"] }
-
+# These are just for making proving executables, if you are just building a library you don't need them as dependencies in your project
+axiom-eth = { git = "https://github.com/axiom-crypto/axiom-eth.git", branch = "community-edition", default-features = false, features = ["halo2-axiom", "aggregation", "evm", "clap"] }
+snark-verifier-sdk = { git = "https://github.com/axiom-crypto/snark-verifier.git", branch = "community-edition", default-features = false, features = ["loader_halo2"] }
 
 [dev-dependencies]
 test-log = "0.2.11"

--- a/src/scaffold/mod.rs
+++ b/src/scaffold/mod.rs
@@ -9,6 +9,7 @@ use axiom_eth::util::{
 use halo2_base::{
     gates::builder::{
         CircuitBuilderStage, GateThreadBuilder, MultiPhaseThreadBreakPoints, RangeCircuitBuilder,
+        RangeWithInstanceCircuitBuilder, RangeWithInstanceConfig,
     },
     halo2_proofs::{
         circuit::{Layouter, SimpleFloorPlanner},
@@ -30,10 +31,7 @@ use halo2_base::{
 };
 use serde::de::DeserializeOwned;
 use snark_verifier_sdk::{
-    halo2::{
-        aggregation::{RangeWithInstanceCircuitBuilder, RangeWithInstanceConfig},
-        gen_snark_shplonk, read_snark, PoseidonTranscript,
-    },
+    halo2::{gen_snark_shplonk, read_snark, PoseidonTranscript},
     read_pk, CircuitExt, NativeLoader,
 };
 use std::{


### PR DESCRIPTION
Update `halo2-lib`, `snark-verifier`, `axiom-eth` to branch `community-edition` for compatibility

Fixes https://github.com/axiom-crypto/halo2-lib/issues/63