### PR TITLE
Pin dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,14 +6,14 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rand = "0.8"
-ark-std = { version = "0.3.0", features = ["print-trace"] }
-serde = { version = "1.0", default-features = false, features = ["derive"] }
-serde_json = "1.0"
-log = "0.4"
-env_logger = "0.10"
-clap = { version = "4.1", features = ["derive"] }
-clap-num = "1.0.2"
+rand = "=0.8"
+ark-std = { version = "=0.3.0", features = ["print-trace"] }
+serde = { version = "=1.0", default-features = false, features = ["derive"] }
+serde_json = "=1.0"
+log = "=0.4"
+env_logger = "=0.10"
+clap = { version = "=4.1", features = ["derive"] }
+clap-num = "=1.0.2"
 
 # halo2
 halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2023_02_02" }
@@ -28,8 +28,8 @@ axiom-eth = { git = "https://github.com/axiom-crypto/axiom-eth.git", branch = "c
 snark-verifier-sdk = { git = "https://github.com/axiom-crypto/snark-verifier.git", branch = "community-edition", default-features = false, features = ["loader_halo2"] }
 
 [dev-dependencies]
-test-log = "0.2.11"
-ethers-core = "2.0.6"
+test-log = "=0.2.11"
+ethers-core = "=2.0.6"
 
 [features]
 default = []


### PR DESCRIPTION
Currently, new patch releases are breaking the build. So this PR locks the dependencies to the versions mentioned in Cargo.toml and this fixes the build error on a fresh clone of halo2-scaffold.

Related: https://github.com/axiom-crypto/halo2-scaffold/issues/14

Not sure if this is the best way to fix the error since I think `cargo build --locked` should have worked but it didn't work for me.