### PR TITLE
Update axiom-eth dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ serde = { version = "=1.0", default-features = false, features = ["derive"] }
 serde_json = "=1.0"
 log = "=0.4"
 env_logger = "=0.10"
-clap = { version = "=4.1", features = ["derive"] }
+clap = { version = "=4.0", features = ["derive"] }
 clap-num = "=1.0.2"
 
 # halo2
@@ -24,7 +24,7 @@ halo2-base = { git = "https://github.com/axiom-crypto/halo2-lib", tag = "v0.3.0-
 poseidon = { git = "https://github.com/axiom-crypto/halo2-lib", tag = "v0.3.0-ce" }
 # Axiom Evm wrapper 
 # These are just for making proving executables, if you are just building a library you don't need them as dependencies in your project
-axiom-eth = { git = "https://github.com/axiom-crypto/axiom-eth.git", rev = "c09477a",  default-features = false, features = ["halo2-axiom", "aggregation", "evm", "clap"] }
+axiom-eth = { git = "https://github.com/axiom-crypto/axiom-eth.git", branch = "community-edition", default-features = false, features = ["halo2-axiom", "aggregation", "evm", "clap"] }
 snark-verifier-sdk = { git = "https://github.com/axiom-crypto/snark-verifier.git", tag = "v0.1.1-ce", default-features = false, features = ["loader_halo2"] }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ halo2-base = { git = "https://github.com/axiom-crypto/halo2-lib", tag = "v0.3.0-
 poseidon = { git = "https://github.com/axiom-crypto/halo2-lib", tag = "v0.3.0-ce" }
 # Axiom Evm wrapper 
 # These are just for making proving executables, if you are just building a library you don't need them as dependencies in your project
-axiom-eth = { git = "https://github.com/axiom-crypto/axiom-eth.git", branch = "community-edition", default-features = false, features = ["halo2-axiom", "aggregation", "evm", "clap"] }
+axiom-eth = { git = "https://github.com/axiom-crypto/axiom-eth.git", rev = "c09477a",  default-features = false, features = ["halo2-axiom", "aggregation", "evm", "clap"] }
 snark-verifier-sdk = { git = "https://github.com/axiom-crypto/snark-verifier.git", tag = "v0.1.1-ce", default-features = false, features = ["loader_halo2"] }
 
 [dev-dependencies]


### PR DESCRIPTION
When I run mock prover, etc., I get the following error.

```
cargo run --example halo2_lib -- --name halo2_lib -k 8 mock
    Updating crates.io index
    Updating git repository `https://github.com/axiom-crypto/axiom-eth.git`
    Updating git repository `https://github.com/axiom-crypto/halo2-lib`
    Updating git repository `https://github.com/privacy-scaling-explorations/halo2.git`
    Updating git repository `https://github.com/axiom-crypto/snark-verifier.git`
    Updating git repository `https://github.com/axiom-crypto/halo2.git`
    Updating git repository `https://github.com/privacy-scaling-explorations/halo2curves.git`
    Updating git repository `https://github.com/axiom-crypto/halo2.git`
    Updating git repository `https://github.com/scroll-tech/poseidon-circuit.git`
    Updating git repository `https://github.com/privacy-scaling-explorations/halo2.git`
    Updating git repository `https://github.com/privacy-scaling-explorations/halo2curves`
error: failed to select a version for `clap`.
    ... required by package `halo2-scaffold v0.2.0 (/Users/halo2-scaffold)`
versions that meet the requirements `=4.1` are: 4.1.14, 4.1.13, 4.1.12, 4.1.11, 4.1.10, 4.1.9, 4.1.8, 4.1.7, 4.1.6, 4.1.5, 4.1.4, 4.1.3, 4.1.2, 4.1.1, 4.1.0

all possible versions conflict with previously selected packages.

  previously selected package `clap v4.0.13`
    ... which satisfies dependency `clap = "=4.0.13"` of package `axiom-eth v0.2.1 (https://github.com/axiom-crypto/axiom-eth.git?branch=community-edition#014a2d05)`
    ... which satisfies git dependency `axiom-eth` of package `halo2-scaffold v0.2.0 (/Users/halo2-scaffold)`

failed to select a version for `clap` which could resolve this conflict
```
As you may know, the axiom-eth dependency was [updated](https://github.com/axiom-crypto/axiom-eth/commit/014a2d059e48f8f4ad83a7650f1d0bf9a69a056a#diff-dc5e242fdc7c9fdf27fc0c9bec394ba202a7159d741a3ee1e6a5320be8c77a69R21) last week.
The easiest way to get it to work correctly is to specify the previous version in Cargo.toml.

Ignore this PR if you do not need temporary measures